### PR TITLE
Pull out abstract E2E test

### DIFF
--- a/src/test/kotlin/dartzee/e2e/AbstractE2ETest.kt
+++ b/src/test/kotlin/dartzee/e2e/AbstractE2ETest.kt
@@ -1,0 +1,26 @@
+package dartzee.e2e
+
+import dartzee.helper.AbstractRegistryTest
+import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
+import dartzee.utils.PREFERENCES_BOOLEAN_SHOW_ANIMATIONS
+import dartzee.utils.PREFERENCES_INT_AI_SPEED
+import dartzee.utils.PreferenceUtil
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+
+@Tag("e2e")
+abstract class AbstractE2ETest : AbstractRegistryTest() {
+    override fun getPreferencesAffected() =
+        listOf(
+            PREFERENCES_INT_AI_SPEED,
+            PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE,
+            PREFERENCES_BOOLEAN_SHOW_ANIMATIONS
+        )
+
+    @BeforeEach
+    open fun beforeEach() {
+        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 0)
+        PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, true)
+        PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_SHOW_ANIMATIONS, false)
+    }
+}

--- a/src/test/kotlin/dartzee/e2e/AbstractE2ETest.kt
+++ b/src/test/kotlin/dartzee/e2e/AbstractE2ETest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 
 @Tag("e2e")
-abstract class AbstractE2ETest : AbstractRegistryTest() {
+open class AbstractE2ETest : AbstractRegistryTest() {
     override fun getPreferencesAffected() =
         listOf(
             PREFERENCES_INT_AI_SPEED,

--- a/src/test/kotlin/dartzee/e2e/SimulationE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/SimulationE2E.kt
@@ -9,7 +9,6 @@ import dartzee.core.bean.NumberField
 import dartzee.core.bean.ScrollTable
 import dartzee.game.GameType
 import dartzee.getRows
-import dartzee.helper.AbstractTest
 import dartzee.helper.beastDartsModel
 import dartzee.helper.insertPlayer
 import dartzee.screen.ai.AISimulationSetupDialog
@@ -22,17 +21,17 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class SimulationE2E : AbstractTest() {
+class SimulationE2E : AbstractE2ETest() {
     @BeforeEach
-    fun beforeEach() {
+    override fun beforeEach() {
+        super.beforeEach()
+
         InjectedThings.simulationRunner = SimulationRunner()
     }
 
     @Test
-    @Tag("e2e")
     fun `Should be able to run a simulation of 500 games`() {
         val model = beastDartsModel()
         val player = insertPlayer(model = model)

--- a/src/test/kotlin/dartzee/e2e/SyncE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/SyncE2E.kt
@@ -40,9 +40,11 @@ import java.util.*
 import javax.swing.JButton
 import javax.swing.JOptionPane
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class SyncE2E : AbstractE2ETest() {
+    @BeforeEach
     override fun beforeEach() {
         super.beforeEach()
 

--- a/src/test/kotlin/dartzee/e2e/SyncE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/SyncE2E.kt
@@ -12,7 +12,6 @@ import dartzee.db.PlayerEntity
 import dartzee.game.GameLaunchParams
 import dartzee.game.GameLauncher
 import dartzee.game.GameType
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.DEFAULT_X01_CONFIG
 import dartzee.helper.TEST_DB_DIRECTORY
 import dartzee.helper.TEST_ROOT
@@ -34,9 +33,6 @@ import dartzee.sync.SyncManager
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings
-import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.io.File
@@ -44,16 +40,12 @@ import java.util.*
 import javax.swing.JButton
 import javax.swing.JOptionPane
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class SyncE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() =
-        listOf(PREFERENCES_INT_AI_SPEED, PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE)
+class SyncE2E : AbstractE2ETest() {
+    override fun beforeEach() {
+        super.beforeEach()
 
-    @BeforeEach
-    fun before() {
         InjectedThings.databaseDirectory = TEST_DB_DIRECTORY
         InjectedThings.mainDatabase = Database(dbName = UUID.randomUUID().toString())
         DartsDatabaseUtil.initialiseDatabase(InjectedThings.mainDatabase)
@@ -63,9 +55,6 @@ class SyncE2E : AbstractRegistryTest() {
         InjectedThings.syncConfigurer = SyncConfigurer(store)
 
         File(TEST_DB_DIRECTORY).mkdirs()
-
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 50)
-        PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, true)
     }
 
     @AfterEach
@@ -74,7 +63,6 @@ class SyncE2E : AbstractRegistryTest() {
         File(TEST_ROOT).deleteRecursively()
     }
 
-    @Tag("e2e")
     @Test
     fun `Syncing two games with same local ID`() {
         val (winner, loser) = createPlayers()
@@ -108,7 +96,6 @@ class SyncE2E : AbstractRegistryTest() {
         x01Wins.size shouldBe 2
     }
 
-    @Tag("e2e")
     @Test
     fun `Syncing deleted data`() {
         val (winner, loser) = createPlayers()

--- a/src/test/kotlin/dartzee/e2e/TestDartzeeE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestDartzeeE2E.kt
@@ -6,7 +6,6 @@ import dartzee.dartzee.DartzeeCalculator
 import dartzee.db.DartzeeRoundResultEntity
 import dartzee.game.GameType
 import dartzee.game.prepareParticipants
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.AchievementSummary
 import dartzee.helper.allTwenties
 import dartzee.helper.beastDartsModel
@@ -23,27 +22,15 @@ import dartzee.helper.totalIsFifty
 import dartzee.`object`.Dart
 import dartzee.`object`.SegmentType
 import dartzee.utils.InjectedThings
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import dartzee.utils.insertDartzeeRules
 import dartzee.zipDartRounds
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestDartzeeE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() = listOf(PREFERENCES_INT_AI_SPEED)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 100)
-    }
-
+class TestDartzeeE2E : AbstractE2ETest() {
     @Test
-    @Tag("e2e")
     fun `E2E - Dartzee`() {
         InjectedThings.dartzeeCalculator = DartzeeCalculator()
 
@@ -86,7 +73,6 @@ class TestDartzeeE2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - Dartzee - 2 player team`() {
         InjectedThings.dartzeeCalculator = DartzeeCalculator()
 

--- a/src/test/kotlin/dartzee/e2e/TestGameLoadE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestGameLoadE2E.kt
@@ -19,9 +19,11 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import javax.swing.SwingUtilities
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class TestGameLoadE2E : AbstractE2ETest() {
+    @BeforeEach
     override fun beforeEach() {
         super.beforeEach()
         PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, false)

--- a/src/test/kotlin/dartzee/e2e/TestGameLoadE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestGameLoadE2E.kt
@@ -7,7 +7,6 @@ import dartzee.game.GameLaunchParams
 import dartzee.game.GameLauncher
 import dartzee.game.GameType
 import dartzee.getRows
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.DEFAULT_X01_CONFIG
 import dartzee.helper.retrieveGame
 import dartzee.helper.retrieveParticipant
@@ -15,28 +14,20 @@ import dartzee.`object`.Dart
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.AbstractDartsGameScreen
 import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
 import dartzee.utils.PreferenceUtil
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import javax.swing.SwingUtilities
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestGameLoadE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() =
-        listOf(PREFERENCES_INT_AI_SPEED, PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 0)
+class TestGameLoadE2E : AbstractE2ETest() {
+    override fun beforeEach() {
+        super.beforeEach()
         PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, false)
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - Game load and AI resume`() {
         val (winner, loser) = createPlayers()
 

--- a/src/test/kotlin/dartzee/e2e/TestGolfE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestGolfE2E.kt
@@ -34,7 +34,6 @@ import dartzee.drtTrebleFour
 import dartzee.drtTrebleSeventeen
 import dartzee.game.GameType
 import dartzee.game.prepareParticipants
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.AchievementSummary
 import dartzee.helper.beastDartsModel
 import dartzee.helper.insertGame
@@ -43,24 +42,12 @@ import dartzee.helper.predictableDartsModel
 import dartzee.helper.retrieveAchievementsForPlayer
 import dartzee.helper.retrieveTeam
 import dartzee.`object`.Dart
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import dartzee.zipDartRounds
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestGolfE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() = listOf(PREFERENCES_INT_AI_SPEED)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 100)
-    }
-
+class TestGolfE2E : AbstractE2ETest() {
     @Test
-    @Tag("e2e")
     fun `E2E - Golf`() {
         val game = insertGame(gameType = GameType.GOLF, gameParams = "18")
 
@@ -87,7 +74,6 @@ class TestGolfE2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - Golf - Gambler, stop threshold`() {
         val game = insertGame(gameType = GameType.GOLF, gameParams = "9")
         val (gamePanel, listener) = setUpGamePanel(game)
@@ -136,7 +122,6 @@ class TestGolfE2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - 9 holes - Team of 2`() {
         val game = insertGame(gameType = GameType.GOLF, gameParams = "9")
         val (gamePanel, listener) = setUpGamePanel(game)

--- a/src/test/kotlin/dartzee/e2e/TestMatchE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestMatchE2E.kt
@@ -26,10 +26,13 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import javax.swing.JTabbedPane
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class TestMatchE2E : AbstractE2ETest() {
+    @BeforeEach
     override fun beforeEach() {
+        super.beforeEach()
         PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, false)
     }
 

--- a/src/test/kotlin/dartzee/e2e/TestMatchE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestMatchE2E.kt
@@ -12,7 +12,6 @@ import dartzee.game.GameLauncher
 import dartzee.game.GameType
 import dartzee.game.MatchMode
 import dartzee.game.X01Config
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.DEFAULT_X01_CONFIG
 import dartzee.helper.insertDartsMatch
 import dartzee.helper.retrieveDartsMatch
@@ -21,29 +20,20 @@ import dartzee.screen.game.MatchSummaryPanel
 import dartzee.screen.game.scorer.MatchScorer
 import dartzee.screen.game.x01.X01MatchScreen
 import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
 import dartzee.utils.PreferenceUtil
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import javax.swing.JTabbedPane
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestMatchE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() =
-        listOf(PREFERENCES_INT_AI_SPEED, PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 0)
+class TestMatchE2E : AbstractE2ETest() {
+    override fun beforeEach() {
         PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, false)
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - Two game match`() {
         val match = insertDartsMatch(games = 2, matchParams = "", mode = MatchMode.FIRST_TO)
         match.gameType = GameType.X01

--- a/src/test/kotlin/dartzee/e2e/TestResignationE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestResignationE2E.kt
@@ -8,32 +8,16 @@ import dartzee.game.GameType
 import dartzee.game.X01Config
 import dartzee.game.state.IWrappedParticipant
 import dartzee.getQuestionDialog
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.insertGame
 import dartzee.helper.insertPlayer
 import dartzee.`object`.SegmentType
-import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import javax.swing.JButton
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestResignationE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() =
-        listOf(PREFERENCES_INT_AI_SPEED, PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 100)
-        PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, true)
-    }
-
+class TestResignationE2E : AbstractE2ETest() {
     @Test
-    @Tag("e2e")
     fun `Resigning mid-game - X01`() {
         val game =
             insertGame(
@@ -65,7 +49,6 @@ class TestResignationE2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `Resigning mid-game - Golf`() {
         val game = insertGame(gameType = GameType.GOLF, gameParams = "9")
 

--- a/src/test/kotlin/dartzee/e2e/TestResizeE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestResizeE2E.kt
@@ -1,30 +1,17 @@
 package dartzee.e2e
 
 import dartzee.game.GameType
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.DEFAULT_X01_CONFIG
 import dartzee.helper.beastDartsModel
 import dartzee.helper.insertGame
 import dartzee.helper.insertPlayer
 import dartzee.`object`.Dart
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import io.kotest.matchers.comparables.shouldBeLessThan
 import java.awt.Dimension
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestResizeE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() = listOf(PREFERENCES_INT_AI_SPEED)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 100)
-    }
-
+class TestResizeE2E : AbstractE2ETest() {
     @Test
-    @Tag("e2e")
     fun `E2E - Small dartboard`() {
         val game = insertGame(gameType = GameType.X01, gameParams = DEFAULT_X01_CONFIG.toJson())
 

--- a/src/test/kotlin/dartzee/e2e/TestRoundTheClockE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestRoundTheClockE2E.kt
@@ -32,7 +32,6 @@ import dartzee.game.ClockType
 import dartzee.game.GameType
 import dartzee.game.RoundTheClockConfig
 import dartzee.game.prepareParticipants
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.AchievementSummary
 import dartzee.helper.beastDartsModel
 import dartzee.helper.insertGame
@@ -41,25 +40,13 @@ import dartzee.helper.predictableDartsModel
 import dartzee.helper.retrieveAchievementsForPlayer
 import dartzee.helper.retrieveTeam
 import dartzee.`object`.Dart
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import dartzee.zipDartRounds
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestRoundTheClockE2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() = listOf(PREFERENCES_INT_AI_SPEED)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 100)
-    }
-
+class TestRoundTheClockE2E : AbstractE2ETest() {
     @Test
-    @Tag("e2e")
     fun `E2E - RTC - perfect game`() {
         val game =
             insertGame(
@@ -91,7 +78,6 @@ class TestRoundTheClockE2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - RTC - unordered`() {
         val game =
             insertGame(
@@ -153,7 +139,6 @@ class TestRoundTheClockE2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - In Order- Team of 2`() {
         val game =
             insertGame(

--- a/src/test/kotlin/dartzee/e2e/TestX01E2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestX01E2E.kt
@@ -6,7 +6,6 @@ import dartzee.game.FinishType
 import dartzee.game.GameType
 import dartzee.game.X01Config
 import dartzee.game.prepareParticipants
-import dartzee.helper.AbstractRegistryTest
 import dartzee.helper.AchievementSummary
 import dartzee.helper.DEFAULT_X01_CONFIG
 import dartzee.helper.beastDartsModel
@@ -17,29 +16,14 @@ import dartzee.helper.predictableDartsModel
 import dartzee.helper.retrieveAchievementsForPlayer
 import dartzee.helper.retrieveTeam
 import dartzee.`object`.Dart
-import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
-import dartzee.utils.PREFERENCES_INT_AI_SPEED
-import dartzee.utils.PreferenceUtil
 import dartzee.zipDartRounds
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-class TestX01E2E : AbstractRegistryTest() {
-    override fun getPreferencesAffected() =
-        listOf(PREFERENCES_INT_AI_SPEED, PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE)
-
-    @BeforeEach
-    fun beforeEach() {
-        PreferenceUtil.saveInt(PREFERENCES_INT_AI_SPEED, 100)
-        PreferenceUtil.saveBoolean(PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE, true)
-    }
-
+class TestX01E2E : AbstractE2ETest() {
     @Test
-    @Tag("e2e")
     fun `E2E - 501 - 9 dart game`() {
         val game = insertGame(gameType = GameType.X01, gameParams = DEFAULT_X01_CONFIG.toJson())
 
@@ -76,7 +60,6 @@ class TestX01E2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - 501 - 9 dart game, relaxed finish`() {
         val game =
             insertGame(
@@ -107,7 +90,6 @@ class TestX01E2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - 101 - relaxed`() {
         val game =
             insertGame(
@@ -173,7 +155,6 @@ class TestX01E2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - 301 - bust and mercy rule`() {
         val game =
             insertGame(
@@ -216,7 +197,6 @@ class TestX01E2E : AbstractRegistryTest() {
     }
 
     @Test
-    @Tag("e2e")
     fun `E2E - 501 - Team of 2`() {
         val game = insertGame(gameType = GameType.X01, gameParams = DEFAULT_X01_CONFIG.toJson())
         val (gamePanel, listener) = setUpGamePanel(game)


### PR DESCRIPTION
Extract some common setup stuff for E2E tests. Also disabling animations via the preference - before, the tests were getting away with this due to the ResourceCache happening to not be initialised. Trying to play sounds in CI fails because we're in a headless linux environment with no audio devices: `java.lang.IllegalArgumentException: No line matching interface Clip is supported.`