### PR TITLE
Don't allow total = 0 for "divisible by" dartzee rule

### DIFF
--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleMultipleOf.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleMultipleOf.kt
@@ -3,7 +3,7 @@ package dartzee.dartzee.aggregate
 class DartzeeTotalRuleMultipleOf : AbstractDartzeeRuleTotalSize() {
     override fun getRuleIdentifier() = "MultipleOf"
 
-    override fun isValidTotal(total: Int) = total % target == 0
+    override fun isValidTotal(total: Int) = total % target == 0 && total > 0
 
     override fun toString() = "Total multiple of"
 

--- a/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeTotalRuleMultipleOf.kt
+++ b/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeTotalRuleMultipleOf.kt
@@ -15,6 +15,7 @@ class TestDartzeeTotalRuleMultipleOf : AbstractDartzeeRuleTest<DartzeeTotalRuleM
         rule.isValidTotal(20) shouldBe false
         rule.isValidTotal(21) shouldBe true
         rule.isValidTotal(22) shouldBe false
+        rule.isValidTotal(0) shouldBe false
     }
 
     @Test


### PR DESCRIPTION
https://trello.com/c/XYv4CXek/218-dartzee-total-divisible-by-shouldnt-allow-0