### PR TITLE
[Party mode] End game tweaks

### DIFF
--- a/src/main/kotlin/dartzee/screen/game/AbstractGameStatisticsPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/AbstractGameStatisticsPanel.kt
@@ -1,15 +1,21 @@
 package dartzee.screen.game
 
 import dartzee.core.bean.ScrollTable
+import dartzee.core.bean.makeTransparentTextPane
 import dartzee.core.util.MathsUtil
 import dartzee.core.util.TableUtil
 import dartzee.core.util.addUnique
+import dartzee.core.util.alignCentrally
+import dartzee.core.util.append
+import dartzee.core.util.setFontSize
 import dartzee.game.UniqueParticipantName
 import dartzee.game.state.AbstractPlayerState
 import dartzee.game.state.IWrappedParticipant
 import dartzee.`object`.Dart
+import dartzee.utils.InjectedThings
 import java.awt.BorderLayout
 import java.awt.Color
+import java.awt.Dimension
 import javax.swing.JPanel
 import javax.swing.UIManager
 import javax.swing.border.EmptyBorder
@@ -67,6 +73,40 @@ abstract class AbstractGameStatisticsPanel<PlayerState : AbstractPlayerState<Pla
         if (isSufficientData()) {
             buildTableModel()
         }
+
+        val activeCount = playerStates.count { it.wrappedParticipant.participant.isActive() }
+        if (InjectedThings.partyMode && activeCount <= 1) {
+            addGameOverMessage(playerStates)
+        }
+    }
+
+    private fun addGameOverMessage(playerStates: List<PlayerState>) {
+        val winner = playerStates.first { it.wrappedParticipant.participant.finishingPosition == 1 }
+        val heading =
+            makeTransparentTextPane().apply {
+                border = EmptyBorder(10, 0, 20, 0)
+                alignCentrally()
+                setFontSize(36)
+                append("Game Over!")
+            }
+
+        heading.preferredSize = Dimension(100, 65)
+        add(heading, BorderLayout.NORTH)
+
+        val textPane =
+            makeTransparentTextPane().apply {
+                alignCentrally()
+                setFontSize(18)
+
+                append("Congrats to ")
+                append(winner.wrappedParticipant.getParticipantName(), true)
+                append(" on the win!")
+                append("\n\n")
+                append("When you're done looking at the stats, this window can be closed.")
+            }
+
+        textPane.preferredSize = Dimension(100, 250)
+        add(textPane, BorderLayout.SOUTH)
     }
 
     private fun isSufficientData(): Boolean {

--- a/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
+++ b/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
@@ -5,6 +5,7 @@ import dartzee.db.GameEntity
 import dartzee.game.state.AbstractPlayerState
 import dartzee.preferences.Preferences
 import dartzee.screen.game.scorer.AbstractDartsScorerPausable
+import dartzee.utils.InjectedThings
 import dartzee.utils.InjectedThings.preferenceService
 import javax.swing.SwingUtilities
 
@@ -77,6 +78,10 @@ abstract class GamePanelPausable<
             !getCurrentPlayerState().isHuman() && preferenceService.get(Preferences.aiAutoContinue)
         ) {
             getCurrentScorer().toggleResume()
+        }
+
+        if (InjectedThings.partyMode) {
+            allPlayersFinished()
         }
     }
 

--- a/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorerPausable.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorerPausable.kt
@@ -6,6 +6,7 @@ import dartzee.game.state.IWrappedParticipant
 import dartzee.logging.CODE_PLAYER_PAUSED
 import dartzee.logging.CODE_PLAYER_UNPAUSED
 import dartzee.screen.game.GamePanelPausable
+import dartzee.utils.InjectedThings
 import dartzee.utils.InjectedThings.logger
 import dartzee.utils.ResourceCache.ICON_PAUSE
 import dartzee.utils.ResourceCache.ICON_RESUME
@@ -24,7 +25,10 @@ abstract class AbstractDartsScorerPausable<PlayerState : AbstractPlayerState<Pla
 
     init {
         btnResume.preferredSize = Dimension(30, 30)
-        panelSouth.add(btnResume, BorderLayout.EAST)
+        if (!InjectedThings.partyMode) {
+            panelSouth.add(btnResume, BorderLayout.EAST)
+        }
+
         btnResume.isVisible = false
         btnResume.icon = ICON_RESUME
         btnResume.toolTipText = "Resume throwing"

--- a/src/main/kotlin/dartzee/screen/game/x01/GameStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/x01/GameStatisticsPanelX01.kt
@@ -9,6 +9,7 @@ import dartzee.game.X01Config
 import dartzee.game.state.X01PlayerState
 import dartzee.`object`.Dart
 import dartzee.screen.game.AbstractGameStatisticsPanel
+import dartzee.utils.InjectedThings
 import dartzee.utils.calculateThreeDartAverage
 import dartzee.utils.getScoringDarts
 import dartzee.utils.isCheckoutDart
@@ -27,10 +28,12 @@ open class GameStatisticsPanelX01(gameParams: String) :
     val nfSetupThreshold = NumberField()
 
     init {
-        add(panel, BorderLayout.NORTH)
-        panel.add(lblSetupThreshold)
+        if (!InjectedThings.partyMode) {
+            add(panel, BorderLayout.NORTH)
+            panel.add(lblSetupThreshold)
+            panel.add(nfSetupThreshold)
+        }
 
-        panel.add(nfSetupThreshold)
         nfSetupThreshold.columns = 10
 
         nfSetupThreshold.value = 100

--- a/src/test/kotlin/dartzee/e2e/TestPartyModeE2E.kt
+++ b/src/test/kotlin/dartzee/e2e/TestPartyModeE2E.kt
@@ -9,16 +9,11 @@ import dartzee.bean.ScrollTableDartsGame
 import dartzee.clickButton
 import dartzee.drtDoubleTwenty
 import dartzee.drtInnerFourteen
-import dartzee.drtInnerOne
 import dartzee.drtInnerSeven
-import dartzee.drtMissTwelve
 import dartzee.drtOuterFive
 import dartzee.drtOuterFourteen
 import dartzee.drtOuterNineteen
 import dartzee.drtOuterOne
-import dartzee.drtOuterSeven
-import dartzee.drtOuterSixteen
-import dartzee.drtOuterTwelve
 import dartzee.drtOuterTwenty
 import dartzee.drtTrebleFive
 import dartzee.drtTrebleNineteen
@@ -31,11 +26,14 @@ import dartzee.screen.DartsApp
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.DartsGamePanel
 import dartzee.screen.game.DartsGameScreen
+import dartzee.screen.game.x01.GameStatisticsPanelX01
 import dartzee.waitForAssertionWithReturn
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import javax.swing.JButton
+import javax.swing.JTextPane
 import javax.swing.SwingUtilities
 import org.junit.jupiter.api.Test
 
@@ -73,13 +71,14 @@ class TestPartyModeE2E : AbstractE2ETest() {
         gamePanel.throwHumanRound(drtTrebleNineteen(), drtInnerFourteen(), drtOuterFourteen()) // 36
         gamePanel.throwHumanRound(drtOuterTwenty(), drtDoubleTwenty(), drtOuterTwenty()) // 0
 
-        gamePanel.clickChild<JButton> { it.isVisible && it.toolTipText == "Resume throwing" }
-        gamePanel.throwHumanRound(drtOuterSixteen(), drtInnerOne(), drtOuterSeven()) // 12
-        gamePanel.throwHumanRound(drtMissTwelve(), drtOuterTwelve()) // 0
-
         // Check game outcome
         gameWindow.getScorer("Alice").lblResult.text shouldBe "12 Darts"
-        gameWindow.getScorer("Bob").lblResult.text shouldBe "14 Darts"
+        gameWindow.getScorer("Bob").lblResult.text shouldBe "Unfinished"
+
+        val statsPane = gameWindow.getChild<GameStatisticsPanelX01>()
+        statsPane.shouldBeVisible()
+        val extraMessage = statsPane.getChild<JTextPane> { it.text.contains("Congrats") }
+        extraMessage.text.shouldContain("Congrats to Alice on the win!")
         gameWindow.dispose()
 
         // Check leaderboard
@@ -90,7 +89,7 @@ class TestPartyModeE2E : AbstractE2ETest() {
         leaderboardTable
             .getRows()
             .map { it.filterIndexed { index: Int, _ -> index != 1 } }
-            .shouldContainExactly(arrayOf(1, "Alice", 1L, 12), arrayOf(2, "Bob", 1L, 14))
+            .shouldContainExactly(arrayOf(1, "Alice", 1L, 12))
 
         // Reload the game
         SwingUtilities.invokeAndWait { GameLauncher().loadAndDisplayGame(gamePanel.getGameId()) }
@@ -98,7 +97,7 @@ class TestPartyModeE2E : AbstractE2ETest() {
         val loadedWindow = ScreenCache.getDartsGameScreen(gamePanel.getGameId())!!
         loadedWindow.shouldBeVisible()
         loadedWindow.getScorer("Alice").lblResult.text shouldBe "12 Darts"
-        loadedWindow.getScorer("Bob").lblResult.text shouldBe "14 Darts"
+        loadedWindow.getScorer("Bob").lblResult.text shouldBe "Unfinished"
     }
 
     private fun launchApp(): DartsApp {

--- a/src/test/kotlin/dartzee/screen/game/x01/TestGameStatisticsPanelX01.kt
+++ b/src/test/kotlin/dartzee/screen/game/x01/TestGameStatisticsPanelX01.kt
@@ -1,5 +1,7 @@
 package dartzee.screen.game.x01
 
+import com.github.alyssaburlton.swingtest.findChild
+import dartzee.core.bean.NumberField
 import dartzee.game.FinishType
 import dartzee.game.X01Config
 import dartzee.game.state.X01PlayerState
@@ -11,6 +13,8 @@ import dartzee.`object`.Dart
 import dartzee.screen.game.AbstractGameStatisticsPanelTest
 import dartzee.screen.game.getRowIndex
 import dartzee.screen.game.getValueForRow
+import dartzee.utils.InjectedThings
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
@@ -31,6 +35,14 @@ class TestGameStatisticsPanelX01 :
 
         val panelTwo = factoryStatsPanel(301)
         panelTwo.nfSetupThreshold.getMaximum() shouldBe 300
+    }
+
+    @Test
+    fun `Should not add setup threshold to screen in party mode`() {
+        InjectedThings.partyMode = true
+
+        val panel = factoryStatsPanel()
+        panel.findChild<NumberField>().shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
In this PR:

- Hide play/pause controls in party mode
- Hide "setup threshold" in game stats
- Automatically end the game when 1 player left who hasn't finished
- Include game over text, and instruction to close the window